### PR TITLE
MSVC source code character. A getter to the state member

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 include(utils)
 include(vars)
 
+if(MSVC)
+    add_compile_options("$<$<C_COMPILER_ID:MSVC>:/source-charset:utf-8>")
+    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/source-charset:utf-8>")
+endif()
+
 # see configure
 # Checks for header files
 check_header("stdbool.h")

--- a/http/client/WebSocketClient.h
+++ b/http/client/WebSocketClient.h
@@ -49,14 +49,16 @@ public:
         return http_resp_;
     }
 
-private:
     enum State {
         CONNECTING,
         CONNECTED,
         WS_UPGRADING,
         WS_OPENED,
         WS_CLOSED,
-    } state;
+    };
+
+private:
+    enum State state;
     HttpParserPtr       http_parser_;
     HttpRequestPtr      http_req_;
     HttpResponsePtr     http_resp_;
@@ -64,6 +66,9 @@ private:
     // ping/pong
     int                 ping_interval;
     int                 ping_cnt;
+
+public:
+    enum State status() { return state; }
 };
 
 }


### PR DESCRIPTION
1.CMakeLists.txt: Set the MSVC compiler source code character set to UTF-8;
2.WebSocketClient.h: Add a getter function named status to the state member variable;